### PR TITLE
Added js linkable headers to FAQ

### DIFF
--- a/essays/FAQ.html
+++ b/essays/FAQ.html
@@ -11,9 +11,10 @@
     <meta property="og:site_name" content="lipamanka's website">
     <meta property="og:url" content="https://lipamanka.github.io">
     <meta property="og:image" content="http://lipamanka.gay/images/lipamanka.png">
-    <link rel="stylesheet" href="https://lipamanka.gay/essays/FAQCSS.css">
+    <link rel="stylesheet" href="./FAQCSS.css"><!-- switched to relative link -->
     <script data-goatcounter="https://lipamanka.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
-    <script defer src="/scripts/expand-all-javascript.js"></script>
+    <script defer src="../scripts/expand-all-javascript.js"></script><!-- switched to relative link -->
+    <script defer src="../scripts/header-links-javascript.js"></script><!-- switched to relative link -->
 </head>
 <body>
   <p>

--- a/essays/FAQCSS.css
+++ b/essays/FAQCSS.css
@@ -128,3 +128,19 @@ details {
         }
     }
 } 
+
+a.headerlink {
+    text-decoration: none;
+    font-size: 0.8em;
+    padding: 0 4px 0 4px;
+    visibility: hidden;
+}
+
+a.headerlink:hover {
+    color: #00B0E4;
+    background-color: #424242;
+}
+
+:hover > a.headerlink {
+    visibility: visible;
+}

--- a/scripts/header-links-javascript.js
+++ b/scripts/header-links-javascript.js
@@ -1,0 +1,31 @@
+// go through every element with an ID
+const elementsWithId = document.body.querySelectorAll('[id]');
+
+elementsWithId.forEach(idElement => {
+    // creates the following hyperlink in the element:
+    // <a class="headerlink" href="#barebones-and-philosophy" title="Link to this heading">¶</a>
+    
+    // ignore the main title and expand/collapse all button
+    if (idElement.id=='frequently-asked-questions-and-misconceptions'
+     || idElement.id=='expAll') {
+        return
+    }
+
+    // create hyperlink element
+    const headerlink = document.createElement('a');
+
+    // give text symbol
+    headerlink.textContent = "¶";
+
+    // give class for styles
+    headerlink.classList.add('headerlink');
+
+    // give clickable link properties
+    headerlink.href = `#${idElement.id}`;
+
+    // give hover flavourtext
+    headerlink.title = "Link to this heading";
+
+    // put in correct place in flow
+    idElement.appendChild(headerlink);
+});


### PR DESCRIPTION
The javascript adds a small hyperlinked ¶ symbol to every element in FAQ.html with an ID (with exceptions). 

This allows people to copy a link to a specific header in the document to share it.

The styles at the bottom of FAQCSS.css can be tweaked to look however suits best.
