### PR TITLE
add header links script to semantic spaces dictionary

### DIFF
--- a/essays/dictionary.html
+++ b/essays/dictionary.html
@@ -11,9 +11,10 @@
     <meta property="og:site_name" content="lipamanka's website">
     <meta property="og:url" content="https://lipamanka.github.io">
     <meta property="og:image" content="http://lipamanka.gay/images/lipamanka.png">
-    <link rel="stylesheet" href="https://lipamanka.gay/essays/FAQCSS.css">
+    <link rel="stylesheet" href="./FAQCSS.css"><!-- switched to relative link -->
     <script data-goatcounter="https://lipamanka.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
-    <script defer src="/scripts/expand-all-javascript.js"></script>
+    <script defer src="../scripts/expand-all-javascript.js"></script><!-- switched to relative link -->
+    <script defer src="../scripts/header-links-javascript.js"></script><!-- switched to relative link -->
 </head>
 <body>
     <p>


### PR DESCRIPTION
not sure why i didnt consider this as equally a possibility and just as useful, but this adds the ability to navigate to each ID'd header of the semantic spaces dictionary using the same hyperlink buttons